### PR TITLE
feat: add conventional commit validation to PR titles

### DIFF
--- a/.github/workflows/semantic-title.yml
+++ b/.github/workflows/semantic-title.yml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow ensures that the [Conventional Commits](https://www.conventionalcommits.org/en/) standard is used when creating PR titles