### PR TITLE
fix: removing a webpack comment that was causing an error on the FE

### DIFF
--- a/src/utils/reportAccessibility.ts
+++ b/src/utils/reportAccessibility.ts
@@ -8,7 +8,7 @@ export const reportAccessibility = async (
 		typeof window !== 'undefined' &&
 		process.env.NODE_ENV !== 'production'
 	) {
-		const axe = await import(/* webpackIgnore: true */ '@axe-core/react');
+		const axe = await import('@axe-core/react');
 		const ReactDOM = await import('react-dom');
 
 		axe.default(App, ReactDOM, 1000, config);


### PR DESCRIPTION
This fixes an error that throws on the Front End due to webpack ignoring, and not bundling, the a11y stuff.

This does now cause a warning in CLI that I can't seem to get rid of but everything seems to work.