### PR TITLE
chore: updated runbook and added some a11y/perf improvements

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -6,7 +6,7 @@ module.exports = {
 		'max-empty-lines': 2,
 		'max-nesting-depth': 4,
 		'number-no-trailing-zeros': true,
-		'string-quotes': 'double',
+		'string-quotes': 'single',
 		'length-zero-no-unit': true,
 		'declaration-block-no-duplicate-properties': true,
 		'declaration-block-no-redundant-longhand-properties': true,

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -35,8 +35,8 @@ Create `.eslintrc.js` file in the root of the project to configure.
 
 ```json
 // package.json "scripts" object
-"lint-js": "eslint '*/**/*.{js,jsx,ts,tsx}' --fix",
-"lint-ts": "tsc -p tsconfig.json --noEmit",
+"lint:js": "eslint '*/**/*.{js,jsx,ts,tsx}' --fix",
+"lint:ts": "tsc -p tsconfig.json --noEmit",
 ```
 
 Copied `.eslintrc.js` content from Ryan's starter.
@@ -58,7 +58,7 @@ Copied `.stylelintrc.js` content from Ryan's starter.
 
 ```json
 // package.json "scripts" object
-"lint-css": "stylelint '*/**/*.{css}' --fix",
+"lint:css": "stylelint '*/**/*.{css}' --fix",
 ```
 
 ### Set up Prettier
@@ -107,9 +107,9 @@ Set up a `lint-staged.config.js` file in the root of the project because running
 
 ```javascript
 module.exports = {
-	'*.{js,jsx,ts,tsx,json,md}': 'prettier --write',
+	'*.{js,jsx,ts,tsx,json,md,css,scss}': 'prettier --write',
 	'*.{js,jsx,ts,tsx}': 'eslint --fix',
-	'*.{css}': 'stylelint --fix',
+	'*.{css,scss}': 'stylelint --fix',
 	'*.{ts,tsx}': () => 'tsc -p tsconfig.json --noEmit',
 };
 ```
@@ -121,6 +121,11 @@ npx husky add .husky/pre-commit "npx lint-staged"
 ```
 
 Any commits should now be automatically linted and fail with an appropriate error when necessary.
+
+### Husky troubleshooting
+
+-   Even though the prepare script should run on install, you may have to run it manually in your terminal
+-   On Mac to get some of the linting working you may have to set the correct permissions on the husky file: `chmod ug+x .husky/*`
 
 ## Set up PostCSS
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,8 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = {
+	rules: {
+		// TODO: Find a better solution than turning this rule off
+		// it doesn't play nicely with our ticket number commit subject patterns
+		'subject-case': [0],
+	},
+	extends: ['@commitlint/config-conventional'],
+};

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,10 @@
 const nextConfig = {
 	reactStrictMode: true,
 	swcMinify: true,
+	i18n: {
+		locales: ['en'],
+		defaultLocale: 'en',
+	},
 };
 
 module.exports = nextConfig;

--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -1,0 +1,30 @@
+import Document, {
+	Html,
+	Head,
+	Main,
+	NextScript,
+	DocumentContext,
+} from 'next/document';
+
+class MyDocument extends Document {
+	// eslint-disable-next-line
+	static async getInitialProps(ctx: DocumentContext) {
+		const initialProps = await Document.getInitialProps(ctx);
+		return { ...initialProps };
+	}
+
+	// eslint-disable-next-line
+	render() {
+		return (
+			<Html>
+				<Head />
+				<body>
+					<Main />
+					<NextScript />
+				</body>
+			</Html>
+		);
+	}
+}
+
+export default MyDocument;


### PR DESCRIPTION
- Runbook updates with next lint config changes and added husky troubleshooting bit
- Fixed a11y issue with no HTML lang
- Added document page for better control over HTML stuffs (head for perf etc) - let me know if there's a better React-y way to do this?
- Stylelint update for clashing rule with prettier
- Turned off commitlint rule for subject syntax for now as it clashes with our ticket name conventions 